### PR TITLE
Replace button "Initialize" with "Agregar"

### DIFF
--- a/src/feature/readings/Reading.js
+++ b/src/feature/readings/Reading.js
@@ -179,31 +179,35 @@ const Reading = () => {
     }
   };
 
-  // Renderizamos el contenido basado en el estado
-  if (loading) return <p>Cargando...</p>;   // Mientras se cargan los datos
-  if (error) return <button onClick={handleFirstListCreation}>Inicializar una lista</button>;
-  if (error) return <p>{error}</p>;         // Si ocurre un error
-  if (!readings || !readings.genres || readings.genres.length === 0) {
-    return(
-      <div
-        className="button-container"
-        style={{
-          display: 'flex',
-          justifyContent: 'center',
-          alignItems: 'center',
-          gap: '10px',
-        }}
-      >
-        <p>No se encontraron géneros o libros.</p>
-        <AgregarButton userId={userId}/>
-      </div>  // Si no hay géneros, mostramos un mensaje
-    )
-  }
-
   // Manejo del evento para volver al HomePage
   const handleGoToHome = () => {
     navigate('/homePage'); // Ruta del HomePage
   };
+
+  // Renderizamos el contenido basado en el estado
+  if (loading) return <p>Cargando...</p>;   // Mientras se cargan los datos
+  // if (error) return <button onClick={handleFirstListCreation}>Inicializar una lista</button>;
+  // if (error) return <p>{error}</p>;         // Si ocurre un error
+  if (!readings || !readings.genres || readings.genres.length === 0 || error) {
+    return(
+      <div>
+        <HomeButton onClick={handleGoToHome} />
+        <ButtonAllLists/>
+        <div
+          className="button-container"
+          style={{
+            display: 'flex',
+            justifyContent: 'center',
+            alignItems: 'center',
+            gap: '10px',
+          }}
+        >
+          <p>No se encontraron géneros o libros.</p>
+          <AgregarButton userId={userId}/>
+        </div>
+      </div>
+    )
+  }
 
   // Función para manejar el click en un libro
   const handleBookClick = (isbn) => {


### PR DESCRIPTION
Replace button "Initialize" with "Agregar" because:
- In the new frontend version, using Initialize apparently forced the user to refresh the website by end.
- The "Agregar" button is designed to initialize if needed, hence making the "Initialize" button obsolete, and less practical from a user perspective.